### PR TITLE
ci: upgrade actions/setup-python v5 → v6 for Node.js 24

### DIFF
--- a/.github/workflows/build-blog.yml
+++ b/.github/workflows/build-blog.yml
@@ -23,7 +23,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - run: pip install -r requirements.txt


### PR DESCRIPTION
## Problem

After merging #11, `actions/setup-python@v5` was still triggering a deprecation warning in the runner:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/setup-python@v5`.

## Fix

Bump `actions/setup-python` from `v5` to `v6`.

`v6.0.0` (released September 2025) upgrades the action's runtime to Node.js 24. No inputs or behaviour change — it's a drop-in upgrade.