### PR TITLE
fix+feat: UI polish, bug fixes, and SEO improvements

### DIFF
--- a/blog/05_render.py
+++ b/blog/05_render.py
@@ -261,6 +261,11 @@ def render(
                     seen[src_id] = grp
                 if len(seen[src_id]["posts"]) < _SIDEBAR_LIMIT:
                     seen[src_id]["posts"].append(p)
+            # When multiple playlists are present, number the sidebar headings
+            # so readers can distinguish them ("My Watching 1", "My Watching 2", …)
+            if len(grp_list) > 1:
+                for i, grp in enumerate(grp_list, 1):
+                    grp["title"] = f"{meta['title']} {i}"
             sidebar_panels.extend(grp_list)
         else:
             view_all = {

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -173,6 +173,11 @@ main.container { padding-top: 2.5rem; padding-bottom: 2.5rem; }
 }
 .post-card:hover { box-shadow: 0 4px 18px rgba(0,0,0,0.08); }
 
+/* Subtle left-border accent per content source */
+.post-card--github     { border-left: 3px solid #0969da; }
+.post-card--youtube    { border-left: 3px solid #dc2626; }
+.post-card--hackernews { border-left: 3px solid #ea580c; }
+
 .post-card__title {
   font-size: 1.25rem;
   font-weight: 700;

--- a/blog/templates/base.html
+++ b/blog/templates/base.html
@@ -4,6 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{% block title %}{{ repo_name }}{% endblock %}</title>
+  {% block meta %}
+  <meta name="description" content="{{ repo_name }} — a personal blog powered by SimpleGitBlog." />
+  <meta property="og:title" content="{{ repo_name }}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="{{ base_path }}" />
+  {% endblock %}
   <link rel="icon" type="image/svg+xml" href="{{ base_path }}static/favicon.svg" />
   <link rel="stylesheet" href="{{ base_path }}static/style.css" />
 </head>

--- a/blog/templates/index.html
+++ b/blog/templates/index.html
@@ -28,7 +28,7 @@
   {% endif %}
   {% if post.labels %}
   <div class="post-card__labels">
-    {% for lbl in post.labels %}
+    {% for lbl in post.labels if lbl != 'Blog Post' %}
     <a href="{{ base_path }}labels/{{ label_slug(lbl) }}/" class="label">{{ lbl }}</a>
     {% endfor %}
   </div>

--- a/blog/templates/index.html
+++ b/blog/templates/index.html
@@ -61,14 +61,25 @@
   <div class="post-card__meta">
     <a href="{{ base_path }}labels/{{ label_slug('Link Submission') if post.metadata.hn_type == 'story' else label_slug('HN Comment') }}/" class="source-badge source-badge--hackernews">{{ '📰 Link Submission' if post.metadata.hn_type == 'story' else '💬 HN Comment' }}</a>
     <time datetime="{{ post.created_at_iso }}">{{ post.created_at_fmt }}</time>
+    {% if post.metadata.hn_type == 'story' %}
     &middot; {{ post.metadata.points }} pt{% if post.metadata.points != 1 %}s{% endif %}
     &middot; <a href="{{ post.metadata.hn_url }}" target="_blank" rel="noopener noreferrer nofollow">{{ post.metadata.num_comments }} comment{% if post.metadata.num_comments != 1 %}s{% endif %} on HN</a>
+    {% endif %}
   </div>
   <h3 class="post-card__title">
+    {% if post.metadata.hn_type == 'story' %}
     <a href="{{ post.metadata.article_url }}" target="_blank" rel="noopener noreferrer nofollow">{{ post.title }}</a>
+    {% else %}
+    <a href="{{ post.post_url }}">{{ post.title }}</a>
+    {% endif %}
   </h3>
   {% if post.excerpt %}
   <p class="post-card__excerpt">{{ post.excerpt }}</p>
+  {% endif %}
+  {% if post.metadata.hn_type == 'story' %}
+  <a class="post-card__read-more" href="{{ post.post_url }}">Read more &rarr;</a>
+  {% else %}
+  <a class="post-card__read-more" href="{{ post.post_url }}">Read comment &rarr;</a>
   {% endif %}
 </article>
 

--- a/blog/templates/label.html
+++ b/blog/templates/label.html
@@ -18,7 +18,7 @@
     <a href="{{ post.post_url }}">{{ post.title }}</a>
   </h3>
   <div class="post-card__meta">
-    {% if post.avatar_url %}
+    {% if post.source != 'youtube' and post.avatar_url %}
     <img class="avatar avatar--small" src="{{ post.avatar_url }}" alt="{{ post.author }}" width="24" height="24" />
     {% endif %}
     <a href="{{ post.author_url }}" target="_blank" rel="noopener noreferrer nofollow">{{ post.author }}</a>
@@ -29,6 +29,11 @@
     {% if post.comment_count == 1 %}1 comment{% else %}{{ post.comment_count }} comments{% endif %}
     {% endif %}
   </div>
+  {% if post.source == 'youtube' and post.avatar_url %}
+  <a href="{{ post.post_url }}">
+    <img class="post-card__video-thumb" src="{{ post.avatar_url }}" alt="{{ post.title }}" width="320" height="180" loading="lazy" />
+  </a>
+  {% endif %}
   {% if post.labels %}
   <div class="post-card__labels">
     {% for lbl in post.labels %}

--- a/blog/templates/label.html
+++ b/blog/templates/label.html
@@ -36,7 +36,7 @@
   {% endif %}
   {% if post.labels %}
   <div class="post-card__labels">
-    {% for lbl in post.labels %}
+    {% for lbl in post.labels if lbl != label_name %}
     <a href="{{ base_path }}labels/{{ label_slug(lbl) }}/" class="label">{{ lbl }}</a>
     {% endfor %}
   </div>

--- a/blog/templates/post.html
+++ b/blog/templates/post.html
@@ -2,6 +2,19 @@
 
 {% block title %}{{ post.title }} &mdash; {{ repo_name }}{% endblock %}
 
+{% block meta %}
+<meta name="description" content="{{ post.excerpt if post.excerpt else post.title }}" />
+<meta property="og:title" content="{{ post.title }}" />
+<meta property="og:description" content="{{ post.excerpt if post.excerpt else post.title }}" />
+<meta property="og:type" content="article" />
+<meta property="og:url" content="{{ post.post_url }}" />
+{% if post.source == 'youtube' and post.avatar_url %}
+<meta property="og:image" content="{{ post.avatar_url }}" />
+{% elif post.avatar_url %}
+<meta property="og:image" content="{{ post.avatar_url }}" />
+{% endif %}
+{% endblock %}
+
 {% block content %}
 <article class="post">
   <header class="post__header">

--- a/blog/templates/post.html
+++ b/blog/templates/post.html
@@ -20,7 +20,7 @@
   <header class="post__header">
     <h1 class="post__title">{{ post.title }}</h1>
     <div class="post__meta">
-      {% if post.avatar_url %}
+      {% if post.avatar_url and post.source != 'youtube' %}
       <img class="avatar" src="{{ post.avatar_url }}" alt="{{ post.author }}" width="36" height="36" />
       {% endif %}
       <span>

--- a/blog/templates/post.html
+++ b/blog/templates/post.html
@@ -21,7 +21,15 @@
         <time datetime="{{ post.created_at_iso }}">{{ post.created_at_fmt }}</time>
         {% endif %}
         &mdash;
+        {% if post.source == 'github' %}
+        <span class="source-badge source-badge--github">✍️ GitHub</span>
+        {% elif post.source == 'youtube' %}
+        <span class="source-badge source-badge--youtube">🎬 YouTube</span>
+        {% elif post.source == 'hackernews' %}
+        <span class="source-badge source-badge--hackernews">{{ '📰 HN Story' if post.metadata.hn_type == 'story' else '💬 HN Comment' }}</span>
+        {% else %}
         <span class="source-badge source-badge--{{ post.source }}">{{ post.source }}</span>
+        {% endif %}
       </span>
     </div>
     {% if post.labels %}

--- a/blog/utils.py
+++ b/blog/utils.py
@@ -229,8 +229,10 @@ def plain_text_to_html(text: str) -> str:
 
 def extract_excerpt(text: str, max_chars: int = 280) -> str:
     """Return a plain-text excerpt from a Markdown or plain-text body."""
+    # Strip HTML tags first (GitHub issue bodies may contain raw HTML, e.g. <img>)
+    plain = re.sub(r"<[^>]+>", " ", text)
     # Strip Markdown syntax roughly
-    plain = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    plain = re.sub(r"```.*?```", "", plain, flags=re.DOTALL)
     plain = re.sub(r"`[^`]+`", "", plain)
     plain = re.sub(r"!\[.*?\]\(.*?\)", "", plain)
     plain = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", plain)


### PR DESCRIPTION
## Summary

After browsing the live site at https://hanclinto.github.io/SimpleGitBlog/ and reviewing the codebase, I identified several bugs and opportunities for improvement. Each change is a separate commit. Changes are focused, minimal, and well-described.

---

## Bug Fixes

### 1. Fix excerpt HTML tag stripping (`blog/utils.py`)

**Problem:** GitHub issue bodies can contain raw `<img>` HTML tags when users attach images via GitHub's editor (e.g. pasted screenshots). The previous `extract_excerpt()` only stripped Markdown image syntax (`![alt](url)`) but not actual HTML `<img src="..." />` tags, causing raw markup to leak into displayed excerpts on index and label pages.

**Visible on:** The NRC 2026 post excerpt showed `<img width="2048" height="1367" alt="Image" src="..." / For the past several 6 years...`

**Fix:** Added a leading `re.sub(r'<[^>]+>', ' ', text)` pass to strip all HTML tags before Markdown processing.

---

### 2. Fix raw source name in post detail badge (`blog/templates/post.html`)

**Problem:** The source badge on post detail pages showed the raw internal key (`post.source`) which CSS `text-transform: uppercase` rendered as `GITHUB`, `YOUTUBE`, or `HACKERNEWS` — confusing, unstyled raw strings with no descriptive context or emoji.

**Fix:** Map each source to a descriptive, emoji-enhanced label consistent with the index page:
- `github` → `✍️ GitHub`
- `youtube` → `🎬 YouTube`
- `hackernews` (story) → `📰 HN Story`
- `hackernews` (comment) → `💬 HN Comment`

---

### 3. Improve HN post cards in main feed (`blog/templates/index.html`)

**Problem 1:** The HN template showed `points` and `num_comments` for all HN post types. HN comment posts have no `points` or `num_comments` metadata (only stories do), so comments were displaying `0 pts · 0 comments on HN` — misleading noise.

**Problem 2:** GitHub and YouTube post cards have a "Read more →" link to the blog post page, but HN cards had none. The title links to the external article, and there's a comments link to HN — but no path to the actual blog post page where the full content is rendered.

**Fix:** Only show `points`/`num_comments` for HN stories. Add a "Read more →" / "Read comment →" link for all HN feed items. For HN comment cards, the card title now links to the blog post page (which shows the full comment text) rather than the HN URL.

---

### 4. Skip tiny thumbnail avatar on YouTube post detail pages (`blog/templates/post.html`)

**Problem:** For YouTube posts, `post.avatar_url` is the video thumbnail (e.g. `hqdefault.jpg`). Showing this as a 36×36 circular avatar in the post meta row looks awkward — the same image is immediately visible as the full-width embedded video player just below.

**Fix:** Skip the avatar image for YouTube posts; the channel name and video embed already provide all necessary context.

---

### 5. Fix duplicate "My Watching" sidebar headings (`blog/05_render.py`)

**Problem:** When multiple YouTube playlists are configured, each playlist generates its own sidebar panel, all titled "My Watching". This produces identical headings making the sidebar confusing.

**Fix:** When two or more playlist panels are generated, number their headings ("My Watching 1", "My Watching 2", …). A single playlist keeps the clean "My Watching" title.

---

### 6. Omit current label from card pills on label pages (`blog/templates/label.html`)

**Problem:** On `/labels/blog-post/`, every post card showed a "Blog Post" label pill — redundant since the page heading already says "Blog Post — N posts". On `/labels/video/`, every card showed "Video". Other (user-defined) labels were buried by this noise.

**Fix:** Filter `label_name` from the label pills on each card in `label.html`, so only the *other* associated labels are shown.

---

## New Features

### 7. Show video thumbnails on label pages for YouTube posts (`blog/templates/label.html`)

**Problem:** The `/labels/video/` label page showed the `avatar_url` as a tiny 24×24 avatar in the meta row — for YouTube posts this is the video thumbnail image, which looks wrong as a tiny circular avatar. The main index already showed proper 16:9 thumbnails for video cards.

**Fix:** YouTube posts on label pages now render the same `post-card__video-thumb` thumbnail element (linking to the blog post) as the main index does. Non-YouTube posts continue to show the author avatar correctly.

---

### 8. Add SEO meta tags and Open Graph support (`blog/templates/base.html`, `blog/templates/post.html`)

**Problem:** `base.html` had no `<meta>` description, Open Graph, or social card tags, hurting discoverability and social sharing.

**Fix:** Added a `{% block meta %}` override point in `base.html` with site-wide defaults. `post.html` overrides this block with per-post Open Graph tags:
- `og:title` from the post title
- `og:description` from the excerpt (falls back to title)
- `og:type = "article"`
- `og:url` from the post URL
- `og:image` from the post thumbnail when available

---

### 9. Source-type accent borders and cleaner label display (`blog/static/style.css`, `blog/templates/index.html`)

**CSS:** Added subtle left-border color accents per content source on post cards, mirroring the existing source-badge palette:
- GitHub posts → blue (#0969da)
- YouTube posts → red (#dc2626)
- HN posts → orange (#ea580c)

This gives instant visual scent about content type without cluttering the card design.

**Template:** Filtered the synthetic "Blog Post" label pill from GitHub post cards on the index page. The source badge at the top of each card already links to the Blog Post label page, making the pill directly below redundant. User-defined labels (e.g. "AI", "oss-development") continue to appear normally.

---

## Testing

Changes were validated by reviewing the generated HTML structure and cross-checking templates against the live site. No pipeline or dependency changes required.